### PR TITLE
Handling bug caused by bad cache

### DIFF
--- a/slack/src/object_detection.js
+++ b/slack/src/object_detection.js
@@ -59,7 +59,10 @@ const objectsNotification = async (prediction, awsUrl) => {
         ts,
         icon_emoji: ':slack:',
         blocks,
-      }).catch((err) => console.error('Failed to update Message in slack:\n', err.stack));
+      }).catch((err) => {
+        console.error('Failed to update Message in slack:\n', err.stack);
+        redis.del('previous_ts');
+      });
       return;
     }
     web.chat.delete({


### PR DESCRIPTION
前回のslackメーセージがあるというログがあった際、実際にはそのメッセージが削除されていたときエラーを履き続けるというバグの修正